### PR TITLE
Fix: Remove duplicate Footer component in BlogPost layout (Issue #21)

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -130,8 +130,7 @@ const headings = extractHeadings(post.body ?? "");
                         }
                     </div>
                     <BlogTOC headings={headings} post={post} />
-
-                    <Footer />
+                    
                 </div>
             </div>
             <Footer />


### PR DESCRIPTION
Fix: Remove duplicate Footer component in BlogPost layout (Issue #21).