### PR TITLE
fix: remove debug console.log statements from production code

### DIFF
--- a/src/components/BlogContent.astro
+++ b/src/components/BlogContent.astro
@@ -108,7 +108,6 @@ const formatText = (text: string) => {
             // Images - PROCESS BEFORE LINKS to avoid conflict
             .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_, alt, src) => {
                 let imageSrc = src;
-                console.log(src, "image src in blog content");
 
                 // Handle different image path patterns
                 if (src.startsWith("../../assets/")) {
@@ -166,9 +165,6 @@ const sections = parseContent(cleanedContent);
     >
         {
             sections.map((section, _) => {
-                {
-                    console.log(section.type, "blog content section");
-                }
                 if (section.type === "heading") {
                     if (section.level === 1) {
                         return (
@@ -243,7 +239,6 @@ const sections = parseContent(cleanedContent);
                         />
                     );
                 } else {
-                    console.log(section.content, "blog content section");
                     return <div set:html={formatText(section.content)} />;
                 }
             })

--- a/src/components/BlogHeader.astro
+++ b/src/components/BlogHeader.astro
@@ -3,7 +3,6 @@ import { Image } from "astro:assets";
 import FormattedDate from "./FormattedDate.astro";
 
 const { ...post } = Astro.props;
-// console.log(Astro.props);
 ---
 
 <div


### PR DESCRIPTION
## Description
Removes stray `console.log` statements and commented-out logs left in production blog components (`BlogContent.astro` and `BlogHeader.astro`).

Closes #22