### PR TITLE
fix: make BlogHeader back button navigate to blogs

### DIFF
--- a/src/components/BlogHeader.astro
+++ b/src/components/BlogHeader.astro
@@ -18,12 +18,13 @@ const { ...post } = Astro.props;
             {/* Breadcrumb */}
             <nav class="mb-6">
                 <div class="flex items-center space-x-2 text-sm">
-                    <button
-                        class="hover:opacity-75 transition-colors"
+                    <a
+                        href="/blogs"
+                        class="hover:opacity-75 transition-colors inline-block"
                         style={{ color: "var(--theme-primary)" }}
                     >
                         ← Back to blogs
-                    </button>
+                    </a>
                 </div>
             </nav>
 


### PR DESCRIPTION
## Description
Replaces the non-functional `<button>` element in `BlogHeader.astro` with an anchor tag linking to `/blogs`, allowing users to navigate back to the blogs list.

Closes #23