### PR TITLE
fix: use theme variables for window control dots in BlogCode

### DIFF
--- a/src/components/BlogCode.astro
+++ b/src/components/BlogCode.astro
@@ -21,9 +21,21 @@ const { language, code, title } = Astro.props;
     >
         <div class="flex items-center space-x-3">
             <div class="flex space-x-1">
-                <div class="w-3 h-3 bg-red-400 rounded-full"></div>
-                <div class="w-3 h-3 bg-yellow-400 rounded-full"></div>
-                <div class="w-3 h-3 bg-green-400 rounded-full"></div>
+                <div
+                    class="w-3 h-3 rounded-full"
+                    style={{ backgroundColor: "var(--theme-error)" }}
+                >
+                </div>
+                <div
+                    class="w-3 h-3 rounded-full"
+                    style={{ backgroundColor: "var(--theme-warning)" }}
+                >
+                </div>
+                <div
+                    class="w-3 h-3 rounded-full"
+                    style={{ backgroundColor: "var(--theme-success)" }}
+                >
+                </div>
             </div>
             {
                 title && (


### PR DESCRIPTION
## Description
Replaces hardcoded Tailwind color classes (`bg-red-400`, `bg-yellow-400`, `bg-green-400`) in `BlogCode.astro` with theme CSS variables (`--theme-error`, `--theme-warning`, `--theme-success`) for consistent theme styling.

Closes #25